### PR TITLE
avoid layer merges in im.ridgeline.R

### DIFF
--- a/R/im.ridgeline.R
+++ b/R/im.ridgeline.R
@@ -1,4 +1,4 @@
-im.ridgeline <- function(im, scale, palette = c("viridis", "magma", "plasma", "inferno", "cividis", "mako", "rocket", "turbo")) {
+im.ridgeline <- function(im, scale = 1, palette = c("viridis", "magma", "plasma", "inferno", "cividis", "mako", "rocket", "turbo")) {
   
   palette <- palette[1]
   
@@ -19,6 +19,7 @@ im.ridgeline <- function(im, scale, palette = c("viridis", "magma", "plasma", "i
          turbo = 'H')
   
   #Transforming im in a dataframe
+  names(im) <- make.unique(names(im))  # to avoid ridgelines merging same-name layers
   df <- as.data.frame(im, wide = FALSE)
   
   #Final graph


### PR DESCRIPTION
Append numbers to duplicate layer names, so that different layers aren't merged in the same ridgeline.

Example:

ndvi <- im.import("Sentinel2_NDVI_")
names(ndvi)
im.ridgeline(im = ndvi, scale = 1)


Also, set a default value for 'scale', so that the user doesn't always have to specify it manually.

Feel free to ignore any of these! :)